### PR TITLE
Demo of function-kcl to dynamically create Network resources

### DIFF
--- a/kcl/README.md
+++ b/kcl/README.md
@@ -1,0 +1,188 @@
+# function-kcl demo
+
+This demo shows the usage of
+[`function-kcl`](https://github.com/crossplane-contrib/function-kcl) to compose
+resources within a Crossplane composition and its function pipeline.
+
+The [XRD](definition.yaml) offers a simple `Network` claim abstraction that
+allows developers to self-serivce provision network infrastructure, such as
+`VPC` and `InternetGateway`. The following configuration values are exposed on
+this claim:
+
+* `count`: The number of network objects to create.
+* `includeGateway`: True to create an InternetGateway in addition to the VPC.
+* `id`: ID of this Network that will be included in its labels for other objects
+  to discover easily.
+
+The [composition](./composition.yaml) uses [KCL](https://kcl-lang.io/) to
+dynamically compose resources in accordance with the user provided input from
+the XR.
+
+* All input values from the XR are safely extracted, with defaults provided if
+  values were not provided on the XR
+* A labels dictionary is initialized from the `spec.id` value and is set on
+  every created resource
+* In a `for` loop, a `count` number of VPC resources are initialized
+* If `includeGateway` is true, a `count` number of `InternetGateway` resources
+  are initialized in another `for` loop
+* The resulting VPC and gateway objects are returned in the `items` collection
+
+## Usage
+
+This demo provides two XRs that can be used to initiate the creation of network
+resources.
+
+Create a variable number of network resources that includes both `VPC` and
+`InternetGateway` objects:
+
+```console
+crossplane beta render xr-with-gateway.yaml composition.yaml functions.yaml -r
+```
+
+Create network resources that only include `VPC` objects:
+
+```console
+crossplane beta render xr-without-gateway.yaml composition.yaml functions.yaml -r
+```
+
+## Example Output
+
+If we create a `XNetwork` object with `count: 2` and `includeGateway: true`, we
+should see the following output from `crossplane render`, which shows 2 `VPC`
+created and 2 `InternetGateway` created, along with the results providing by
+`function-kcl`:
+
+```console
+❯ crossplane beta render xr-with-gateway.yaml composition.yaml functions.yaml -r
+---
+apiVersion: demo-kcl.crossplane.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: xnetwork-kcl
+status:
+  conditions:
+  - lastTransitionTime: "2024-01-01T00:00:00Z"
+    message: 'Unready resources: resource-gateway-0, resource-gateway-1, resource-vpc-0,
+      and 1 more'
+    reason: Creating
+    status: "False"
+    type: Ready
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: InternetGateway
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: resource-gateway-0
+  generateName: xnetwork-kcl-
+  labels:
+    crossplane.io/composite: xnetwork-kcl
+    networks.meta.fn.crossplane.io/network-id: xnetwork-kcl
+  name: gateway-0
+  ownerReferences:
+  - apiVersion: demo-kcl.crossplane.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XNetwork
+    name: xnetwork-kcl
+    uid: ""
+spec:
+  forProvider:
+    region: eu-west-1
+    vpcIdSelector:
+      matchControllerRef: true
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: InternetGateway
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: resource-gateway-1
+  generateName: xnetwork-kcl-
+  labels:
+    crossplane.io/composite: xnetwork-kcl
+    networks.meta.fn.crossplane.io/network-id: xnetwork-kcl
+  name: gateway-1
+  ownerReferences:
+  - apiVersion: demo-kcl.crossplane.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XNetwork
+    name: xnetwork-kcl
+    uid: ""
+spec:
+  forProvider:
+    region: eu-west-1
+    vpcIdSelector:
+      matchControllerRef: true
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: resource-vpc-0
+  generateName: xnetwork-kcl-
+  labels:
+    crossplane.io/composite: xnetwork-kcl
+    networks.meta.fn.crossplane.io/network-id: xnetwork-kcl
+  name: vpc-0
+  ownerReferences:
+  - apiVersion: demo-kcl.crossplane.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XNetwork
+    name: xnetwork-kcl
+    uid: ""
+spec:
+  forProvider:
+    cidrBlock: 192.168.0.0/16
+    enableDnsHostnames: true
+    enableDnsSupport: true
+    region: eu-west-1
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  annotations:
+    crossplane.io/composition-resource-name: resource-vpc-1
+  generateName: xnetwork-kcl-
+  labels:
+    crossplane.io/composite: xnetwork-kcl
+    networks.meta.fn.crossplane.io/network-id: xnetwork-kcl
+  name: vpc-1
+  ownerReferences:
+  - apiVersion: demo-kcl.crossplane.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: XNetwork
+    name: xnetwork-kcl
+    uid: ""
+spec:
+  forProvider:
+    cidrBlock: 192.168.0.0/16
+    enableDnsHostnames: true
+    enableDnsSupport: true
+    region: eu-west-1
+---
+apiVersion: render.crossplane.io/v1beta1
+kind: Result
+message: created resource "gateway-0:InternetGateway"
+severity: SEVERITY_NORMAL
+step: render-with-kcl
+---
+apiVersion: render.crossplane.io/v1beta1
+kind: Result
+message: created resource "gateway-1:InternetGateway"
+severity: SEVERITY_NORMAL
+step: render-with-kcl
+---
+apiVersion: render.crossplane.io/v1beta1
+kind: Result
+message: created resource "vpc-0:VPC"
+severity: SEVERITY_NORMAL
+step: render-with-kcl
+---
+apiVersion: render.crossplane.io/v1beta1
+kind: Result
+message: created resource "vpc-1:VPC"
+severity: SEVERITY_NORMAL
+step: render-with-kcl
+```

--- a/kcl/claim.yaml
+++ b/kcl/claim.yaml
@@ -1,0 +1,9 @@
+apiVersion: demo-kcl.crossplane.io/v1alpha1
+kind: Network
+metadata:
+ name: network-kcl
+ namespace: default
+spec:
+ id: network-kcl
+ includeGateway: true
+ count: 1

--- a/kcl/composition.yaml
+++ b/kcl/composition.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+ name: xlabels.demo-kcl.crossplane.io
+ labels:
+   provider: aws
+spec:
+  writeConnectionSecretsToNamespace: crossplane-system
+  compositeTypeRef:
+    apiVersion: demo-kcl.crossplane.io/v1alpha1
+    kind: XNetwork
+  mode: Pipeline
+  pipeline:
+  - step: render-with-kcl
+    functionRef:
+      name: function-kcl
+    input:
+      apiVersion: krm.kcl.dev/v1alpha1
+      kind: KCLRun
+      metadata:
+        name: resource
+      spec:
+        target: Resources
+        # OCI, Git or inline sources are supported - we'll use inline here
+        # source: oci://ghcr.io/kcl-lang/crossplane-xnetwork-kcl-function
+        # source: github.com/kcl-lang/modules/crossplane-xnetwork-kcl-function
+        source: |
+          # Get the XR spec fields which are our user input
+          id = option("params")?.oxr?.spec?.id or ""
+          includeGateway = option("params")?.oxr?.spec?.includeGateway or False
+          count = option("params")?.oxr?.spec?.count or 1
+
+          # construct the labels based on the XR spec.id
+          network_id_labels = {"networks.meta.fn.crossplane.io/network-id" = id} if id else {}
+
+          # Create number of VPCs according to spec.count
+          vpcs = [{
+              apiVersion = "ec2.aws.upbound.io/v1beta1"
+              kind = "VPC"
+              metadata.name = "vpc-{}".format(i)
+              metadata.labels = network_id_labels
+              spec.forProvider = {
+                  region = "eu-west-1"
+                  cidrBlock = "192.168.0.0/16"
+                  enableDnsSupport = True
+                  enableDnsHostnames = True
+              }
+          } for i in range(count)]
+
+          # Optionally create number of gateways according to spec.count and spec.includeGateway
+          gateways = [{
+              apiVersion = "ec2.aws.upbound.io/v1beta1"
+              kind = "InternetGateway"
+              metadata.name = "gateway-{}".format(i)
+              metadata.labels = network_id_labels
+              spec.forProvider = {
+                  region = "eu-west-1"
+                  vpcIdSelector.matchControllerRef = True
+              }
+          } for i in range(count)] if includeGateway else []
+
+          # return any created VPCs and gateways
+          items = vpcs + gateways

--- a/kcl/definition.yaml
+++ b/kcl/definition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+ name: xnetworks.demo-kcl.crossplane.io
+spec:
+  group: demo-kcl.crossplane.io
+  names:
+    kind: XNetwork
+    plural: xnetworks
+  claimNames:
+    kind: Network
+    plural: networks
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              count:
+                type: integer
+                description: The number of network objects to create.
+              includeGateway:
+                type: boolean
+                description: True to create an InternetGateway in addition to the VPC.
+              id:
+                type: string
+                description: ID of this Network that will be included in its labels for other objects to discover easily.

--- a/kcl/functions.yaml
+++ b/kcl/functions.yaml
@@ -1,0 +1,9 @@
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-kcl
+  annotations:
+    # This tells crossplane beta render to connect to the function locally.
+    # render.crossplane.io/runtime: Development
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-kcl:v0.2.0

--- a/kcl/xr-with-gateway.yaml
+++ b/kcl/xr-with-gateway.yaml
@@ -1,0 +1,8 @@
+apiVersion: demo-kcl.crossplane.io/v1alpha1
+kind: XNetwork
+metadata:
+ name: xnetwork-kcl
+spec:
+  count: 2
+  includeGateway: true
+  id: xnetwork-kcl

--- a/kcl/xr-without-gateway.yaml
+++ b/kcl/xr-without-gateway.yaml
@@ -1,0 +1,9 @@
+apiVersion: demo-kcl.crossplane.io/v1alpha1
+kind: XNetwork
+metadata:
+ name: xnetwork-kcl
+spec:
+  count: 1
+  includeGateway: false
+  id: xnetwork-kcl 
+  


### PR DESCRIPTION
This PR adds a new demo that uses [`function-kcl`](https://github.com/crossplane-contrib/function-kcl) to compose resources within a Crossplane composition and its function pipeline.